### PR TITLE
Allow changing wallet chain (namespace)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ See also the [RPC methods in WalletConnect](https://docs.walletconnect.org/v/1.0
 Class method to set the wallet metadata as object (v2). See [the WalletConnect standard for the format details](https://docs.walletconnect.com/2.0/specs/clients/core/pairing/data-structures#metadata).  
 Optional. If not provided, when v2, it sends the default pyWalletConnect metadata as wallet identification.
 
+`WCClient.set_wallet_namespace( wallet_namespace )`  
+Class method to set the wallet [namespace](https://docs.walletconnect.com/2.0/advanced/glossary#namespaces), i.e. supported chain collection.  
+Only for v2, optional. Defaults to 'eip155' aka EVM-based chains.
+
 `WCClient.set_project_id( project_id )`  
 Class method to set the WalletConnect project id. This is mandatory to use a project id when  
 using WC v2 with the official central bridge relay.

--- a/pywalletconnect/client.py
+++ b/pywalletconnect/client.py
@@ -49,6 +49,7 @@ class WCClient:
     wc_uri_pattern = regex_compile(r"^wc:(.+)@(\d)\?(.+)$")
     project_id = ""
     origin_domain = ""
+    wallet_namespace = "eip155"
     wallet_metadata = {
         "description": f"pyWalletConnect v{VERSION} by BitLogiK",
         "url": "https://github.com/bitlogik/pyWalletConnect",
@@ -69,6 +70,11 @@ class WCClient:
     def __del__(self):
         """Dying gasp and clean close"""
         self.close()
+
+    @classmethod
+    def set_wallet_namespace(cls, wallet_namespace):
+        """Can override the default wallet namespace."""
+        cls.wallet_namespace = wallet_namespace
 
     @classmethod
     def set_wallet_metadata(cls, wallet_metadata):

--- a/pywalletconnect/client_v2waku.py
+++ b/pywalletconnect/client_v2waku.py
@@ -314,7 +314,7 @@ class WCv2ClientLegacy(WCClient):
                     "metadata": self.wallet_metadata,
                 },
                 "expiry": now_epoch + 14400,
-                "state": {"accounts": [f"eip155:{chain_id}:{account_address}"]},
+                "state": {"accounts": [f"{self.wallet_namespace}:{chain_id}:{account_address}"]},
             },
         )
         msgb = self.enc_channel.encrypt_payload(json_encode(respo))


### PR DESCRIPTION
To make it easier to support non-Ethereum chains, allow setting a default wallet namespace.