### PR TITLE
Allow responding with a JSON-RPC error object

### DIFF
--- a/pywalletconnect/client_v1.py
+++ b/pywalletconnect/client_v1.py
@@ -109,9 +109,9 @@ class WCv1Client(WCClient):
             msg_ready = (None, "", [])
         return msg_ready
 
-    def reply(self, req_id, result):
+    def reply(self, req_id, result, as_error=False):
         """Send a RPC response to the webapp through the relay."""
-        payload_bin = json_rpc_pack_response(req_id, result)
+        payload_bin = json_rpc_pack_response(req_id, result, as_error)
         datafull = {
             "topic": self.app_peer_id,
             "type": "pub",

--- a/pywalletconnect/client_v2irn.py
+++ b/pywalletconnect/client_v2irn.py
@@ -184,14 +184,14 @@ class WCv2Client(WCClient):
             self.close()
             raise WCClientException(f"{resp_type} timeout")
 
-    def reply(self, req_id, result):
+    def reply(self, req_id, result, as_error=False):
         """Send a RPC response to the current topic to the webapp through the relay."""
-        self._reply(self.wallet_id, req_id, result)
+        self._reply(self.wallet_id, req_id, result, as_error=as_error)
 
-    def _reply(self, topic, req_id, result, tag=0):
+    def _reply(self, topic, req_id, result, tag=0, as_error=False):
         """Send a RPC response to the webapp through the relay."""
         logger.debug("Sending response result : %s , %s", req_id, result)
-        payload_bin = json_rpc_pack_response(req_id, result)
+        payload_bin = json_rpc_pack_response(req_id, result, as_error)
         msgbp = self.topics[topic]["secure_channel"].encrypt_payload(payload_bin, None)
         logger.debug("Sending result reply.")
         self.publish(topic, msgbp, tag, "Sending result")

--- a/pywalletconnect/client_v2waku.py
+++ b/pywalletconnect/client_v2waku.py
@@ -179,9 +179,9 @@ class WCv2ClientLegacy(WCClient):
             self.close()
             raise WCClientException(f"{resp_type} timeout")
 
-    def reply(self, req_id, result):
+    def reply(self, req_id, result, as_error=False):
         """Send a RPC response to the webapp through the relay."""
-        payload_bin = json_rpc_pack_response(req_id, result)
+        payload_bin = json_rpc_pack_response(req_id, result, as_error=as_error)
         msgbp = self.enc_channel.encrypt_payload(payload_bin, None)
         logger.debug("Sending result reply.")
         self.publish(self.wallet_id, msgbp, "Sending result")

--- a/pywalletconnect/json_rpc.py
+++ b/pywalletconnect/json_rpc.py
@@ -63,12 +63,13 @@ def json_rpc_unpack_response(raw_response):
     return resp_obj["result"]
 
 
-def json_rpc_pack_response(idmsg, result_obj):
+def json_rpc_pack_response(idmsg, result_obj, as_error=False):
     """Build a JSON-RPC response."""
+    response_type = "error" if as_error else "result"
     request_obj = {
         "jsonrpc": "2.0",
         "id": idmsg,
-        "result": result_obj,
+        response_type: result_obj,
     }
     return json_encode(request_obj).encode("utf8")
 


### PR DESCRIPTION
Signing request rejections and signing errors must be returned as JSON-RPC error objects. This PR adds a boolean parameter to the WCClient.reply() function that specifies that the error object must be constructed and sent.