### PR TITLE
Fix for non-integer chainID

### DIFF
--- a/pywalletconnect/client_v2irn.py
+++ b/pywalletconnect/client_v2irn.py
@@ -293,14 +293,14 @@ class WCv2Client(WCClient):
                         # Namespace usage case 3 (and 2)
                         nps = "requiredNamespaces"
                         chain_ids += [
-                            int(c.split(":")[-1])
+                            c.split(":")[-1]
                             for c in read_data[2][nps][self.wallet_namespace]["chains"]
                         ]
                     if opt_namespace is not None:
                         # Namespace usage case 1 (and 2)
                         nps = "optionalNamespaces"
                         chain_ids += [
-                            int(c.split(":")[-1])
+                            c.split(":")[-1]
                             for c in read_data[2][nps][self.wallet_namespace]["chains"]
                         ]
                     # Use methods and events from optional is both present


### PR DESCRIPTION
According to [CAIP-2](https://chainagnostic.org/CAIPs/caip-2) the reference part of chain_id is not necessarily an integer number. Recent changes introduced in dfa4958ce83d2cf57983f594bfa77ba5e7970a11 break compatibility with chains having alphanumeric chain_ids. I suggest to keep it as strings.